### PR TITLE
fix: camera capture on Safari browser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 name: Release
 
+# Fix for broken build: https://github.com/softprops/action-gh-release/issues/236
 permissions:
   contents: write
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Budibase Camera (beta)
+# Budibase Camera
 
 ![budibase camera demo](https://user-images.githubusercontent.com/110921612/209187286-58d8ae54-1275-4ed6-b7de-6cedf15a80ec.gif)
 
@@ -7,13 +7,8 @@
 
 Take pictures in Budibase! This component allows you to snap a photo directly into an Attachment field in a Budibase DB data source. It's a form field  component and it saves the captured image files directly to the attachment column you configure.
 
-## Known issues
-
-- doesn't currently work in Safari or Firefox. Chromium browsers only supported for now.
-
 ## Todos
 
 - add camera selection
 - add more options (timer, resolution, format, etc.)
-- allow photo deletion from field
-- wider browser support
+- allow photo deletion from the field

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Budibase Camera
+# Budibase Camera (beta)
 
 ![budibase camera demo](https://user-images.githubusercontent.com/110921612/209187286-58d8ae54-1275-4ed6-b7de-6cedf15a80ec.gif)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # Budibase Camera (beta)
-[![Release](https://github.com/Netix-AI-RnD/budibase-component-camera/actions/workflows/release.yml/badge.svg)](https://github.com/Netix-AI-RnD/budibase-component-camera/actions/workflows/release.yml)
-
 ![budibase camera demo](https://user-images.githubusercontent.com/110921612/209187286-58d8ae54-1275-4ed6-b7de-6cedf15a80ec.gif)
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Budibase Camera (beta)
+[![Release](https://github.com/Netix-AI-RnD/budibase-component-camera/actions/workflows/release.yml/badge.svg)](https://github.com/Netix-AI-RnD/budibase-component-camera/actions/workflows/release.yml)
 
 ![budibase camera demo](https://user-images.githubusercontent.com/110921612/209187286-58d8ae54-1275-4ed6-b7de-6cedf15a80ec.gif)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Budibase Camera (beta)
+
 ![budibase camera demo](https://user-images.githubusercontent.com/110921612/209187286-58d8ae54-1275-4ed6-b7de-6cedf15a80ec.gif)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "camera",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Take pictures in Budibase 📸",
   "license": "MIT",
   "svelte": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "camera",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Take pictures in Budibase 📸",
   "license": "MIT",
   "svelte": "index.js",
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@crownframework/svelte-error-boundary": "^1.0.3",
+    "image-capture": "^0.4.0",
     "svelte": "^3.49.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "camera",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Take pictures in Budibase 📸",
   "license": "MIT",
   "svelte": "index.js",

--- a/src/Component.svelte
+++ b/src/Component.svelte
@@ -2,6 +2,7 @@
   import { getContext, onDestroy } from "svelte";
   import Captures from "./Captures.svelte";
   import Loading from "./Loading.svelte";
+  import { ImageCapture } from "image-capture";
 
   export let field;
   export let label;

--- a/src/Component.svelte
+++ b/src/Component.svelte
@@ -62,10 +62,6 @@
       imageCapture = new ImageCapture(track);
 
       videoSource.srcObject = stream;
-      // Fix for iOS Safari from https://leemartin.dev/hello-webrtc-on-safari-11-e8bcb5335295
-      videoSource.setAttribute("autoplay", "");
-      videoSource.setAttribute("muted", "");
-      videoSource.setAttribute("playsinline", "");
       videoSource.play();
       videoSource = videoSource;
 

--- a/src/Component.svelte
+++ b/src/Component.svelte
@@ -61,6 +61,10 @@
       imageCapture = new ImageCapture(track);
 
       videoSource.srcObject = stream;
+      // Fix for iOS Safari from https://leemartin.dev/hello-webrtc-on-safari-11-e8bcb5335295
+      videoSource.setAttribute("autoplay", "");
+      videoSource.setAttribute("muted", "");
+      videoSource.setAttribute("playsinline", "");
       videoSource.play();
       videoSource = videoSource;
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,1 @@
+declare module "image-capture";

--- a/yarn.lock
+++ b/yarn.lock
@@ -665,6 +665,11 @@ icss-utils@^5.0.0:
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.1.0.tgz#c6be6858abd013d768e98366ae47e25d5887b1ae"
   integrity sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==
 
+image-capture@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/image-capture/-/image-capture-0.4.0.tgz#67b96608d0b58ecb1337ee335e4492733f6c11ee"
+  integrity sha512-6RWTfqC4ij0AldG+6sQ51XSHTSbwfqMSjVl1GtwNBzbW4UrcfGZeB1Kn749BccvtLb04g5+jSTf1D7q3qHcxpA==
+
 import-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-3.0.0.tgz#20845547718015126ea9b3676b7592fb8bd4cf92"


### PR DESCRIPTION
# Changelog

Camera Capture works on Safari browser with an ImageCapture Polyfill.

Ref: https://github.com/GoogleChromeLabs/imagecapture-polyfill

<img width="1582" alt="Screenshot 2023-07-25 at 10 49 28 AM" src="https://github.com/andz-bb/budibase-component-camera/assets/5203107/737fd4e0-2ded-499a-a94f-ee26291a9880">
